### PR TITLE
Run workflow jobs sequentially to avoid disk space outage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: ['3.11']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-poetry
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -13,10 +13,6 @@ env:
   QUAY_DOCLING_SERVE_CPU_IMAGE_NAME: ds4sd/docling-serve-cpu
   QUAY_DOCLING_SERVE_GPU_IMAGE_NAME: ds4sd/docling-serve
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build_and_publish_cpu_images:
     name: Push docling-serve "CPU only" container image to GHCR and QUAY
@@ -105,6 +101,9 @@ jobs:
           file: Containerfile
           build-args: |
             --build-arg CPU_ONLY=true
+      - name: Remove Local Docker Images
+        run: |
+          docker image prune -af
 
   build_and_publish_gpu_images:
     name: Push docling-serve (with GPU support) container image to GHCR and QUAY


### PR DESCRIPTION
Github Action runners are running out of the space while building both the images in parallel.

This change will build the image sequentially and also clean up the cpu images before start building gpu image.