### PR TITLE
docs: correct multipart/form-data curl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The API provides two endpoints: one for urls, one for files. This is necessary t
 
 ### Common parameters
 
-On top of the source of file (see below), both endpoints support the same parameters, which are the same as the Docling CLI.
+On top of the source of file (see below), both endpoints support the same parameters, which are almost the same as the Docling CLI.
 
 - `from_format` (List[str]): Input format(s) to convert from. Allowed values: `docx`, `pptx`, `html`, `image`, `pdf`, `asciidoc`, `md`. Defaults to all formats.
-- `to_format` (List[str]): Output format(s) to convert to. Allowed values: `md`, `json`, `html`, `text`, `doctags`. Defaults to `md`.
+- `to_formats` (List[str]): Output format(s) to convert to. Allowed values: `md`, `json`, `html`, `text`, `doctags`. Defaults to `md`.
 - `do_ocr` (bool): If enabled, the bitmap content will be processed using OCR. Defaults to `True`.
 - `image_export_mode`: Image export mode for the document (only in case of JSON, Markdown or HTML). Allowed values: embedded, placeholder, referenced. Optional, defaults to `embedded`.
 - `force_ocr` (bool): If enabled, replace any existing text with OCR-generated text over the full content. Defaults to `False`.
@@ -192,14 +192,17 @@ curl -X 'POST' \
   -H 'Content-Type: multipart/form-data' \
   -F 'ocr_engine=easyocr' \
   -F 'pdf_backend=dlparse_v2' \
-  -F 'from_formats=pdf,docx' \
+  -F 'from_formats=pdf' \
+  -F 'from_formats=docx' \
   -F 'force_ocr=false' \
   -F 'image_export_mode=embedded' \
-  -F 'ocr_lang=["en"]' \
+  -F 'ocr_lang=en' \
+  -F 'ocr_lang=pl' \
   -F 'table_mode=fast' \
   -F 'files=@2206.01062v1.pdf;type=application/pdf' \
   -F 'abort_on_error=false' \
   -F 'to_formats=md' \
+  -F 'to_formats=text' \
   -F 'return_as_file=false' \
   -F 'do_ocr=true'
 ```

--- a/docling_serve/gradio_ui.py
+++ b/docling_serve/gradio_ui.py
@@ -396,7 +396,7 @@ with gr.Blocks(
                 file_reset_btn = gr.Button("Reset", scale=1)
 
     # Options
-    with gr.Accordion("Options") as options:
+    with gr.Accordion("Options", open=False) as options:
         with gr.Row():
             with gr.Column(scale=1):
                 to_formats = gr.CheckboxGroup(
@@ -455,23 +455,30 @@ with gr.Blocks(
                 return_as_file = gr.Checkbox(label="Return as File", value=False)
 
     # Document output
-    with gr.Row(visible=False) as content_output:
-        with gr.Tab("Markdown"):
-            output_markdown = gr.Code(
-                language="markdown", wrap_lines=True, show_label=False
-            )
-        with gr.Tab("Markdown-Rendered"):
-            output_markdown_rendered = gr.Markdown(label="Response")
-        with gr.Tab("Docling (JSON)"):
-            output_json = gr.Code(language="json", wrap_lines=True, show_label=False)
-        with gr.Tab("HTML"):
-            output_html = gr.Code(language="html", wrap_lines=True, show_label=False)
-        with gr.Tab("HTML-Rendered"):
-            output_html_rendered = gr.HTML(label="Response")
-        with gr.Tab("Text"):
-            output_text = gr.Code(wrap_lines=True, show_label=False)
-        with gr.Tab("DocTags"):
-            output_doctags = gr.Code(wrap_lines=True, show_label=False)
+    with gr.Column(scale=1) as content_output:
+        with gr.Tabs():
+            with gr.Tab("Markdown"):
+                output_markdown = gr.Code(
+                    language="markdown",
+                    wrap_lines=True,
+                    show_label=False,
+                    container=False
+                )
+            with gr.Tab("Markdown-Rendered"):
+                output_markdown_rendered = gr.Markdown(
+                    label="Response",
+                    container=False
+                )
+            with gr.Tab("Docling (JSON)"):
+                output_json = gr.Code(language="json", wrap_lines=True, show_label=False, container=False)
+            with gr.Tab("HTML"):
+                output_html = gr.Code(language="html", wrap_lines=True, show_label=False, container=False)
+            with gr.Tab("HTML-Rendered"):
+                output_html_rendered = gr.HTML(label="Response", container=False)
+            with gr.Tab("Text"):
+                output_text = gr.Code(wrap_lines=True, show_label=False, container=False)
+            with gr.Tab("DocTags"):
+                output_doctags = gr.Code(wrap_lines=True, show_label=False, container=False)
 
     # File download output
     with gr.Row(visible=False) as file_output:
@@ -500,8 +507,6 @@ with gr.Blocks(
 
     # URL processing
     url_process_btn.click(
-        set_options_visibility, inputs=[false_bool], outputs=[options]
-    ).then(
         set_download_button_label, inputs=[processing_text], outputs=[download_file_btn]
     ).then(
         set_outputs_visibility_process,
@@ -558,7 +563,7 @@ with gr.Blocks(
             output_text,
             output_doctags,
         ],
-    ).then(set_options_visibility, inputs=[true_bool], outputs=[options]).then(
+    ).then(
         set_outputs_visibility_direct,
         inputs=[false_bool, false_bool],
         outputs=[content_output, file_output],
@@ -568,8 +573,6 @@ with gr.Blocks(
 
     # File processing
     file_process_btn.click(
-        set_options_visibility, inputs=[false_bool], outputs=[options]
-    ).then(
         set_download_button_label, inputs=[processing_text], outputs=[download_file_btn]
     ).then(
         set_outputs_visibility_process,
@@ -626,10 +629,10 @@ with gr.Blocks(
             output_text,
             output_doctags,
         ],
-    ).then(set_options_visibility, inputs=[true_bool], outputs=[options]).then(
+    ).then(
         set_outputs_visibility_direct,
         inputs=[false_bool, false_bool],
-        outputs=[content_output, file_output],
+        outputs=[content_output, file_output]
     ).then(
         clear_file_input, inputs=None, outputs=[file_input]
     )


### PR DESCRIPTION
Minor fix, as curl didn't work with arrays or concatenated strings sent.