### PR TITLE
Fix __main__ when workers > 1 or reload enabled

### DIFF
--- a/docling_serve/__main__.py
+++ b/docling_serve/__main__.py
@@ -1,6 +1,5 @@
 import os
 
-from docling_serve.app import app
 from docling_serve.helper_functions import _str_to_bool
 
 # Launch the FastAPI server
@@ -10,8 +9,9 @@ if __name__ == "__main__":
     port = int(os.getenv("PORT", "5001"))
     workers = int(os.getenv("UVICORN_WORKERS", "1"))
     reload = _str_to_bool(os.getenv("RELOAD", "False"))
+
     run(
-        app,
+        "docling_serve.app:app",
         host="0.0.0.0",
         port=port,
         workers=workers,


### PR DESCRIPTION
When reload is set, or when uvicorn workers are more than one, the application cannot start.
That's because Uvicorn requires the application to be passed as an import string (e.g., 'docling_serve.app:app'). This is because Uvicorn needs to manage multiple processes or watch for file changes, which requires knowing how to import the application.