### PR TITLE
ci: fix missing secrets inherit

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -46,6 +46,7 @@ jobs:
       contents: read
       attestations: write
       id-token: write
+    secrets: inherit
 
     uses: ./.github/workflows/job-image.yml
     with:


### PR DESCRIPTION
Fix missing `secrets: inherit` in the image publish pipeline
