### PR TITLE
fix: Remove uv from image, merge ARG and ENV declarations

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -42,8 +42,6 @@ ENV \
     DOCLING_SERVE_ARTIFACTS_PATH=/opt/app-root/src/.cache/docling/models
 
 
-COPY --chown=1001:0 README.md ./
-
 RUN --mount=from=ghcr.io/astral-sh/uv:0.6.1,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/opt/app-root/src/.cache/uv,uid=1001 \
     --mount=type=bind,source=uv.lock,target=uv.lock \

--- a/Containerfile
+++ b/Containerfile
@@ -2,8 +2,8 @@ ARG BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s
 
 FROM ${BASE_IMAGE}
 
-ARG MODELS_LIST="layout tableformer picture_classifier easyocr"
-ARG UV_SYNC_EXTRA_ARGS=""
+ARG MODELS_LIST="layout tableformer picture_classifier easyocr" \
+    UV_SYNC_EXTRA_ARGS=""
 
 USER 0
 
@@ -22,8 +22,6 @@ RUN --mount=type=bind,source=os-packages.txt,target=/tmp/os-packages.txt \
 
 ENV TESSDATA_PREFIX=/usr/share/tesseract/tessdata/
 
-COPY --from=ghcr.io/astral-sh/uv:0.6.1 /uv /uvx /bin/
-
 ###################################################################################################
 # Docling layer                                                                                   #
 ###################################################################################################
@@ -32,20 +30,24 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-# On container environments, always set a thread budget to avoid undesired thread congestion.
-ENV OMP_NUM_THREADS=4
+ENV \
+    # On container environments, always set a thread budget to avoid undesired thread congestion.
+    OMP_NUM_THREADS=4 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    PYTHONIOENCODING=utf-8 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/opt/app-root \
+    DOCLING_SERVE_ARTIFACTS_PATH=/opt/app-root/src/.cache/docling/models
 
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
-ENV PYTHONIOENCODING=utf-8
-ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
-ENV UV_PROJECT_ENVIRONMENT=/opt/app-root
 
-ENV DOCLING_SERVE_ARTIFACTS_PATH=/opt/app-root/src/.cache/docling/models
+COPY --chown=1001:0 README.md ./
 
-COPY --chown=1001:0 pyproject.toml uv.lock README.md ./
-
-RUN --mount=type=cache,target=/opt/app-root/src/.cache/uv,uid=1001 \
+RUN --mount=from=ghcr.io/astral-sh/uv:0.6.1,source=/uv,target=/bin/uv \
+    --mount=type=cache,target=/opt/app-root/src/.cache/uv,uid=1001 \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-install-project --no-dev --all-extras ${UV_SYNC_EXTRA_ARGS}   # --no-extra ${NO_EXTRA}
 
 RUN echo "Downloading models..." && \
@@ -54,7 +56,10 @@ RUN echo "Downloading models..." && \
     chmod -R g=u /opt/app-root/src/.cache
 
 COPY --chown=1001:0 --chmod=664 ./docling_serve ./docling_serve
-RUN --mount=type=cache,target=/opt/app-root/src/.cache/uv,uid=1001 \
+RUN --mount=from=ghcr.io/astral-sh/uv:0.6.1,source=/uv,target=/bin/uv \
+    --mount=type=cache,target=/opt/app-root/src/.cache/uv,uid=1001 \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-dev --all-extras ${UV_SYNC_EXTRA_ARGS}   # --no-extra ${NO_EXTRA}
 
 EXPOSE 5001

--- a/Containerfile
+++ b/Containerfile
@@ -41,7 +41,6 @@ ENV \
     UV_PROJECT_ENVIRONMENT=/opt/app-root \
     DOCLING_SERVE_ARTIFACTS_PATH=/opt/app-root/src/.cache/docling/models
 
-
 RUN --mount=from=ghcr.io/astral-sh/uv:0.6.1,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/opt/app-root/src/.cache/uv,uid=1001 \
     --mount=type=bind,source=uv.lock,target=uv.lock \


### PR DESCRIPTION
Removed uv from container file since its not used at runtime.
Merging ARG and ENV also reduces number of layers from 23 to ~~15~~ 14.

**Issue resolved by this Pull Request:**
Resolves #56 

Partially addresses #25 

I could not test this unfortunantely. Looks like something is breaking podman (even before my changes):
```
$ podman build . --build-arg='UV_SYNC_EXTRA_ARGS=--no-extra=cu124 --no-extra=rapidocr --no-extra=tesserocr' -t docling_serve

...

STEP 19/23: RUN echo "Downloading models..." &&     docling-tools models download -o "${DOCLING_SERVE_ARTIFACTS_PATH}" ${MODELS_LIST} &&     chown -R 1001:0 /opt/app-root/src/.cache &&     chmod -R g=u /opt/app-ro
ot/src/.cache
Downloading models...
There was a problem when trying to write in your cache folder (/opt/app-root/src/.cache/huggingface/hub). You should set the environment variable TRANSFORMERS_CACHE to a writable directory.
Traceback (most recent call last):
  File "/usr/lib64/python3.12/pathlib.py", line 1311, in mkdir
    os.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/opt/app-root/src/.cache/docling/models'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/bin/docling-tools", line 10, in <module>
    sys.exit(app())
             ^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/typer/main.py", line 338, in __call__
    raise e
  File "/opt/app-root/lib64/python3.12/site-packages/typer/main.py", line 321, in __call__
    return get_command(self)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/typer/core.py", line 728, in main
    return _main(
           ^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/typer/core.py", line 197, in _main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/typer/main.py", line 703, in wrapper
    return callback(**use_params)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/docling/cli/models.py", line 77, in download
    output_dir = download_models(
                 ^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/docling/utils/model_downloader.py", line 33, in download_models
    output_dir.mkdir(exist_ok=True, parents=True)
  File "/usr/lib64/python3.12/pathlib.py", line 1315, in mkdir
    self.parent.mkdir(parents=True, exist_ok=True)
  File "/usr/lib64/python3.12/pathlib.py", line 1311, in mkdir
    os.mkdir(self, mode)
PermissionError: [Errno 13] Permission denied: '/opt/app-root/src/.cache/docling'
Error: building at STEP "RUN echo "Downloading models..." &&     docling-tools models download -o "${DOCLING_SERVE_ARTIFACTS_PATH}" ${MODELS_LIST} &&     chown -R 1001:0 /opt/app-root/src/.cache &&     chmod -R g=
u /opt/app-root/src/.cache": while running runtime: exit status 1
```