### PR TITLE
refactor: Use bytes as options key

### DIFF
--- a/docling_serve/docling_conversion.py
+++ b/docling_serve/docling_conversion.py
@@ -265,7 +265,7 @@ ConvertDocumentsRequest = Union[
 
 
 # Document converters will be preloaded and stored in a dictionary
-converters: Dict[str, DocumentConverter] = {}
+converters: Dict[bytes, DocumentConverter] = {}
 
 
 # Custom serializer for PdfFormatOption
@@ -301,7 +301,7 @@ def _serialize_pdf_format_option(pdf_format_option: PdfFormatOption) -> str:
 # Computes the PDF pipeline options and returns the PdfFormatOption and its hash
 def get_pdf_pipeline_opts(  # noqa: C901
     request: ConvertDocumentsOptions,
-) -> Tuple[PdfFormatOption, str]:
+) -> Tuple[PdfFormatOption, bytes]:
     if request.ocr_engine == OcrEngine.EASYOCR:
         try:
             import easyocr  # noqa: F401
@@ -401,7 +401,7 @@ def get_pdf_pipeline_opts(  # noqa: C901
 
     serialized_data = _serialize_pdf_format_option(pdf_format_option)
 
-    options_hash = hashlib.sha1(serialized_data.encode()).hexdigest()
+    options_hash = hashlib.sha1(serialized_data.encode()).digest()
 
     return pdf_format_option, options_hash
 


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

`hexdigest` is a little bit slower and there is no reason to use strings here.

even if you needed to be able to copypaste these keys for some reason you still can: `{b'\xf6\x9bg\xef\xd8\xa8\x8be\x92&\xbc\xaeq\x10\xaf^L\xbd\xd4\xaf': <docling.document_converter.DocumentConverter object at 0x7598596dacc0>}`