### PR TITLE
chore: Remove deprecated type aliases

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -3,7 +3,7 @@ import tempfile
 from contextlib import asynccontextmanager
 from io import BytesIO
 from pathlib import Path
-from typing import Annotated, Any, Dict, List, Optional, Union
+from typing import Annotated, Any, Optional, Union
 
 from docling.datamodel.base_models import DocumentStream, InputFormat
 from docling.document_converter import DocumentConverter
@@ -165,8 +165,8 @@ def create_app():
     def process_url(
         background_tasks: BackgroundTasks, conversion_request: ConvertDocumentsRequest
     ):
-        sources: List[Union[str, DocumentStream]] = []
-        headers: Optional[Dict[str, Any]] = None
+        sources: list[Union[str, DocumentStream]] = []
+        headers: Optional[dict[str, Any]] = None
         if isinstance(conversion_request, ConvertDocumentFileSourcesRequest):
             for file_source in conversion_request.file_sources:
                 sources.append(file_source.to_document_stream())
@@ -202,7 +202,7 @@ def create_app():
     )
     async def process_file(
         background_tasks: BackgroundTasks,
-        files: List[UploadFile],
+        files: list[UploadFile],
         options: Annotated[
             ConvertDocumentsOptions, FormDepends(ConvertDocumentsOptions)
         ],

--- a/docling_serve/docling_conversion.py
+++ b/docling_serve/docling_conversion.py
@@ -2,20 +2,10 @@ import base64
 import hashlib
 import json
 import logging
+from collections.abc import Iterable, Iterator
 from io import BytesIO
 from pathlib import Path
-from typing import (
-    Annotated,
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Annotated, Any, Optional, Union
 
 from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
 from docling.backend.docling_parse_v2_backend import DoclingParseV2DocumentBackend
@@ -47,7 +37,7 @@ _log = logging.getLogger(__name__)
 # Define the input options for the API
 class ConvertDocumentsOptions(BaseModel):
     from_formats: Annotated[
-        List[InputFormat],
+        list[InputFormat],
         Field(
             description=(
                 "Input format(s) to convert from. String or list of strings. "
@@ -59,7 +49,7 @@ class ConvertDocumentsOptions(BaseModel):
     ] = list(InputFormat)
 
     to_formats: Annotated[
-        List[OutputFormat],
+        list[OutputFormat],
         Field(
             description=(
                 "Output format(s) to convert to. String or list of strings. "
@@ -120,7 +110,7 @@ class ConvertDocumentsOptions(BaseModel):
     ] = OcrEngine.EASYOCR
 
     ocr_lang: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         Field(
             description=(
                 "List of languages used by the OCR engine. "
@@ -224,7 +214,7 @@ class HttpSource(BaseModel):
         ),
     ]
     headers: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(
             description="Additional headers used to fetch the urls, "
             "e.g. authorization, agent, etc"
@@ -252,11 +242,11 @@ class FileSource(BaseModel):
 
 
 class ConvertDocumentHttpSourcesRequest(DocumentsConvertBase):
-    http_sources: List[HttpSource]
+    http_sources: list[HttpSource]
 
 
 class ConvertDocumentFileSourcesRequest(DocumentsConvertBase):
-    file_sources: List[FileSource]
+    file_sources: list[FileSource]
 
 
 ConvertDocumentsRequest = Union[
@@ -265,7 +255,7 @@ ConvertDocumentsRequest = Union[
 
 
 # Document converters will be preloaded and stored in a dictionary
-converters: Dict[str, DocumentConverter] = {}
+converters: dict[str, DocumentConverter] = {}
 
 
 # Custom serializer for PdfFormatOption
@@ -301,7 +291,7 @@ def _serialize_pdf_format_option(pdf_format_option: PdfFormatOption) -> str:
 # Computes the PDF pipeline options and returns the PdfFormatOption and its hash
 def get_pdf_pipeline_opts(  # noqa: C901
     request: ConvertDocumentsOptions,
-) -> Tuple[PdfFormatOption, str]:
+) -> tuple[PdfFormatOption, str]:
     if request.ocr_engine == OcrEngine.EASYOCR:
         try:
             import easyocr  # noqa: F401
@@ -361,7 +351,7 @@ def get_pdf_pipeline_opts(  # noqa: C901
             pipeline_options.images_scale = request.images_scale
 
     if request.pdf_backend == PdfBackend.DLPARSE_V1:
-        backend: Type[PdfDocumentBackend] = DoclingParseDocumentBackend
+        backend: type[PdfDocumentBackend] = DoclingParseDocumentBackend
     elif request.pdf_backend == PdfBackend.DLPARSE_V2:
         backend = DoclingParseV2DocumentBackend
     elif request.pdf_backend == PdfBackend.PYPDFIUM2:
@@ -409,12 +399,12 @@ def get_pdf_pipeline_opts(  # noqa: C901
 def convert_documents(
     sources: Iterable[Union[Path, str, DocumentStream]],
     options: ConvertDocumentsOptions,
-    headers: Optional[Dict[str, Any]] = None,
+    headers: Optional[dict[str, Any]] = None,
 ):
     pdf_format_option, options_hash = get_pdf_pipeline_opts(options)
 
     if options_hash not in converters:
-        format_options: Dict[InputFormat, FormatOption] = {
+        format_options: dict[InputFormat, FormatOption] = {
             InputFormat.PDF: pdf_format_option,
             InputFormat.IMAGE: pdf_format_option,
         }

--- a/docling_serve/helper_functions.py
+++ b/docling_serve/helper_functions.py
@@ -1,6 +1,6 @@
 import inspect
 import re
-from typing import List, Type, Union
+from typing import Union
 
 from fastapi import Depends, Form
 from pydantic import BaseModel
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 # Adapted from
 # https://github.com/fastapi/fastapi/discussions/8971#discussioncomment-7892972
-def FormDepends(cls: Type[BaseModel]):
+def FormDepends(cls: type[BaseModel]):
     new_parameters = []
 
     for field_name, model_field in cls.model_fields.items():
@@ -34,8 +34,8 @@ def FormDepends(cls: Type[BaseModel]):
     return Depends(as_form_func)
 
 
-def _to_list_of_strings(input_value: Union[str, List[str]]) -> List[str]:
-    def split_and_strip(value: str) -> List[str]:
+def _to_list_of_strings(input_value: Union[str, list[str]]) -> list[str]:
+    def split_and_strip(value: str) -> list[str]:
         if re.search(r"[;,]", value):
             return [item.strip() for item in re.split(r"[;,]", value)]
         else:

--- a/docling_serve/response_preparation.py
+++ b/docling_serve/response_preparation.py
@@ -3,8 +3,9 @@ import os
 import shutil
 import tempfile
 import time
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Optional, Union
 
 from docling.datamodel.base_models import OutputFormat
 from docling.datamodel.document import ConversionResult, ConversionStatus, ErrorItem
@@ -31,9 +32,9 @@ class DocumentResponse(BaseModel):
 class ConvertDocumentResponse(BaseModel):
     document: DocumentResponse
     status: ConversionStatus
-    errors: List[ErrorItem] = []
+    errors: list[ErrorItem] = []
     processing_time: float
-    timings: Dict[str, ProfilingItem] = {}
+    timings: dict[str, ProfilingItem] = {}
 
 
 class ConvertDocumentErrorResponse(BaseModel):


### PR DESCRIPTION
This is basically `ruff check --select UP --ignore UP007 --fix`

Docling-serve is `python >= 3.10`, docling is `python >= 3.9`
These aliases are deprecated since 3.9.

`UP007` is about Option and Union added in 3.10, I didn't apply it since im unsure if you want to still support 3.9.
