### PR TITLE
fix(docs): Remove comma in convert/source curl example

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,5 +4,7 @@ config:
   first-line-heading: false
   MD033:
     allowed_elements: ["details", "summary"]
+  MD024:
+    siblings_only: true
 globs:
   - "**/*.md"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ curl -X 'POST' \
     "return_as_file": false,
     "do_table_structure": true,
     "include_images": true,
-    "images_scale": 2,
+    "images_scale": 2
   },
   "http_sources": [{"url": "https://arxiv.org/pdf/2206.01062"}]
 }'


### PR DESCRIPTION
Remove comma in convert/source curl example to make it work.

Otherwise it fails with error message:
{"detail":[{"type":"json_invalid","loc":["body",607],"msg":"JSON decode error","input":{},"ctx":{"error":"Expecting property name enclosed in double quotes"}}]}%