### PR TITLE
feat: display version in fastapi docs

### DIFF
--- a/docling_serve/__main__.py
+++ b/docling_serve/__main__.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.metadata
 import logging
 import platform
 import sys
@@ -51,9 +51,7 @@ def version_callback(value: bool) -> None:
 def callback(
     version: Annotated[
         Union[bool, None],
-        typer.Option(
-            "--version", help="Show the version and exit.", callback=version_callback
-        ),
+        typer.Option(help="Show the version and exit.", callback=version_callback),
     ] = None,
     verbose: Annotated[
         int,
@@ -298,5 +296,4 @@ def main() -> None:
 
 # Launch the CLI when calling python -m docling_serve
 if __name__ == "__main__":
-
     main()

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import logging
 import tempfile
 from contextlib import asynccontextmanager
@@ -60,7 +61,6 @@ _log = logging.getLogger(__name__)
 # Context manager to initialize and clean up the lifespan of the FastAPI app
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-
     # Converter with default options
     pdf_format_option, options_hash = get_pdf_pipeline_opts(ConvertDocumentsOptions())
     converters[options_hash] = DocumentConverter(
@@ -85,9 +85,17 @@ async def lifespan(app: FastAPI):
 
 
 def create_app():
+    try:
+        version = importlib.metadata.version("docling_serve")
+    except importlib.metadata.PackageNotFoundError:
+        _log.warning("Unable to get docling_serve version, falling back to 0.0.0")
+
+        version = "0.0.0"
+
     app = FastAPI(
         title="Docling Serve",
         lifespan=lifespan,
+        version=version,
     )
 
     origins = ["*"]
@@ -104,7 +112,6 @@ def create_app():
 
     # Mount the Gradio app
     if docling_serve_settings.enable_ui:
-
         try:
             import gradio as gr
 
@@ -207,7 +214,6 @@ def create_app():
             ConvertDocumentsOptions, FormDepends(ConvertDocumentsOptions)
         ],
     ):
-
         _log.info(f"Received {len(files)} files for processing.")
 
         # Load the uploaded files to Docling DocumentStream

--- a/uv.lock
+++ b/uv.lock
@@ -535,7 +535,7 @@ wheels = [
 
 [[package]]
 name = "docling-serve"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "docling" },


### PR DESCRIPTION
I don't see version anywhere else in UI currently. I did what `--version` code does